### PR TITLE
Set default FAQ limit to -1

### DIFF
--- a/includes/class-gs-faq-shortcode.php
+++ b/includes/class-gs-faq-shortcode.php
@@ -37,7 +37,7 @@ class Genesis_Simple_FAQ_Shortcode {
 		$a = shortcode_atts( array(
 			'id'    => '',
 			'cat'   => '',
-			'limit' => get_option( 'posts_per_page' )
+			'limit' => -1,
 		), $atts );
 
 		// If IDs are set, use them. Otherwise retrieve all.
@@ -50,7 +50,7 @@ class Genesis_Simple_FAQ_Shortcode {
 			'orderby'        => 'post__in',
 			'post_type'      => 'gs_faq',
 			'post__in'       => $ids,
-			'posts_per_page' => $a['limit']
+			'posts_per_page' => $a['limit'],
 		);
 
 		if ( $cats ) {

--- a/includes/class-gs-faq-widget.php
+++ b/includes/class-gs-faq-widget.php
@@ -28,7 +28,7 @@ class Genesis_Simple_FAQ_Widget extends WP_Widget {
 		$this->defaults = array(
 			'title'    => '',
 			'taxonomy' => '',
-			'limit'    => get_option( 'posts_per_page' ),
+			'limit'    => -1,
 		);
 
 		$widget_ops = array(


### PR DESCRIPTION
Makes sense to show all FAQs by default, instead of having the site's `posts_per_page` as the default. See discussion in #29. 