### PR TITLE
Soft deprecate Genesis Simple FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Genesis Simple FAQ
+
 A simple plugin to handle FAQ layout and interaction with a shortcode.
+
+## DEPRECATION NOTICE
+This plugin is now deprecated and will no longer receive feature updates.
+
+Alternatives:
+- Block Editor users: build an FAQ page with the [Atomic Blocks plugin](https://wordpress.org/plugins/atomic-blocks/) using the [Accordion block](https://atomicblocks.com/blocks/accordion-block/).
+- Classic Editor users: check out the wide range of [other FAQ plugins](https://wordpress.org/plugins/search/faq/).
 
 ## Usage
 Adding a FAQ is easy and relies on custom post types to organize and format your FAQs. To add an FAQ, do the following:

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: studiopress, calvinkoepke, nathanrice, modernnerd
 Tags: genesis, faq
 Requires at least: 4.8
-Tested up to: 5.2.2
+Tested up to: 5.4
 Stable tag: 0.9.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -9,6 +9,13 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 A simple plugin to handle FAQ layout and interaction with a shortcode.
 
+== DEPRECATION NOTICE ==
+This plugin is now deprecated and will no longer receive feature updates.
+
+Alternatives:
+- Block Editor users: build an FAQ page with the <a href="https://wordpress.org/plugins/atomic-blocks">Atomic Blocks plugin</a> using the <a href="https://atomicblocks.com/blocks/accordion-block/">Accordion block</a>.
+- Classic Editor users: check out the wide range of <a href="https://wordpress.org/plugins/search/faq/">other FAQ plugins</a>.
+
 == Installation ==
 
 1. Upload the plugin files to the `/wp-content/plugins/plugin-name` directory, or install the plugin through the WordPress plugins screen directly.


### PR DESCRIPTION
Adds a deprecation notice to the readme.md for GitHub, and the readme.txt for WordPress.org.

Points to alternative options for block editor users (Atomic Blocks Accordion block) and Classic Editor users (I linked to the FAQ keyword in the WP.org repo search rather than recommending a specific plugin, so we don't have to track the latest state of all FAQ plugins).
 
### How to test
Code review. 

### Documentation
Will require documentation updates, notably to:
- https://my.studiopress.com/documentation/genesis-simple-faqs/
- https://my.studiopress.com/documentation/genesis-sample-theme/extras/faq-page/
- https://my.studiopress.com/documentation/academy-pro-theme/first-steps/pre-installation-setup/

cc @susannelson 

We also need to decide if we are updating existing themes that use Simple FAQ (Sample, Academy Pro) or if we will retain the plugin in demos for now.

### Notes
Only readme updates — can be pushed to WP.org without a version bump or new zip.
